### PR TITLE
Automatic test suites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Add trusted publishing
+- Add automated tests covering all examples from the specification
+- Add conversion from 0.4 to 0.5 metadata
 
 ### Fixed
 - Fix improper serialisation of `rowIndex` and `columnIndex` in `PlateWell` metadata

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,6 @@ exclude = [
 monostate = "0.1.0"
 serde = { version = "1.0.184", features = ["derive"] }
 serde_json = { version = "1.0.71", features = ["float_roundtrip", "preserve_order"] }
+
+[dev-dependencies]
+json_comments = "0.2.2"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The transitional "omero" metadata is not supported.
 ## Features
 - [x] Serialisation and deserialisation
 - [ ] Validation
-- [ ] Forward conversion
+- [x] Forward conversion
 
 ## Licence
 `ome_zarr_metadata` is licensed under either of

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,9 @@
 #![deny(missing_docs)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
+#[cfg(test)]
+pub(crate) mod tests;
+
 /// Version `0.4` (OME-NGFF) metadata.
 ///
 /// <https://ngff.openmicroscopy.org/0.4/>.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,0 +1,199 @@
+use std::io::Read;
+use std::sync::LazyLock;
+use std::{collections::BTreeMap, path::PathBuf};
+
+use serde::de::DeserializeOwned;
+use serde::Deserialize;
+
+fn strip_comments(jsonc: &str) -> String {
+    let mut s = String::with_capacity(jsonc.len());
+    let mut rd = json_comments::StripComments::new(jsonc.as_bytes());
+    rd.read_to_string(&mut s).unwrap();
+    s
+}
+
+type VersionMap<T> = LazyLock<BTreeMap<(u64, u64), T>>;
+
+static VERSION_DIRS: VersionMap<PathBuf> = LazyLock::new(|| {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("ome-zarr");
+    let Ok(rddir) = std::fs::read_dir(&root) else {
+        return Default::default();
+    };
+    rddir
+        .filter_map(|r| {
+            let entry = r.ok()?;
+            if !entry.file_type().ok()?.is_dir() {
+                return None;
+            };
+            let fname = entry.file_name().into_string().ok()?;
+            let (first, second) = fname.split_once('.')?;
+            let ver = (first.parse::<u64>().ok()?, second.parse::<u64>().ok()?);
+            if ver < (0, 4) {
+                return None;
+            }
+            Some((ver, entry.path()))
+        })
+        .collect()
+});
+
+/// Map from version tuple to directory name to example file stem to JSON content, e.g.
+/// `(0, 5) -> "multiscales_strict" -> "multiscales_example" -> '{"key": "value", ...}'`
+static EXAMPLE_JSON: VersionMap<BTreeMap<String, BTreeMap<String, String>>> = LazyLock::new(|| {
+    let mut out: BTreeMap<(u64, u64), BTreeMap<String, BTreeMap<String, String>>> =
+        BTreeMap::default();
+    for (ver, ver_path_ref) in VERSION_DIRS.iter() {
+        let ver_path = ver_path_ref.join("examples");
+        let Ok(rddir) = std::fs::read_dir(&ver_path) else {
+            continue;
+        };
+
+        for (dir, dir_path) in rddir.filter_map(|r| {
+            let entry = r.ok()?;
+            if !entry.file_type().ok()?.is_dir() {
+                return None;
+            };
+            let fname = entry.file_name().into_string().ok()?;
+
+            let mut path = entry.path();
+            path.push("valid");
+            if !path.is_dir() {
+                path.pop();
+            }
+            Some((fname, path))
+        }) {
+            let Ok(rddir) = std::fs::read_dir(&dir_path) else {
+                continue;
+            };
+            for (fname, content) in rddir.filter_map(|r| {
+                let entry = r.ok()?;
+                if !entry.file_type().ok()?.is_file() {
+                    return None;
+                };
+                let fname = entry.file_name().into_string().ok()?;
+                if fname.starts_with(".config") || !fname.ends_with(".json") {
+                    return None;
+                };
+                let p = entry.path();
+                let jsonc = std::fs::read_to_string(&p).ok()?;
+                let json = strip_comments(&jsonc);
+                let stem = p.file_stem()?.to_str()?.to_string();
+                Some((stem, json))
+            }) {
+                out.entry(*ver)
+                    .or_default()
+                    .entry(dir.clone())
+                    .or_default()
+                    .insert(fname, content);
+            }
+        }
+    }
+    out
+});
+
+#[derive(Debug, Deserialize)]
+pub struct TestSuiteSchema {
+    pub id: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Test {
+    pub formerly: String,
+    // pub description: Option<String>,
+    pub data: serde_json::Value,
+    pub valid: bool,
+}
+
+impl Test {
+    /// Return None if the test passes; an error message otherwise.
+    pub fn test_deser<T: DeserializeOwned + std::fmt::Debug>(&self) -> Option<String> {
+        let result: serde_json::Result<T> = serde_json::from_value(self.data.clone());
+        let msg = match result {
+            Ok(t) => {
+                if self.valid {
+                    return None;
+                }
+                format!(
+                    "test {}: expected invalid data, but got valid {t:?}",
+                    self.formerly
+                )
+            }
+            Err(e) => {
+                if !self.valid {
+                    return None;
+                }
+                format!(
+                    "test {}: expected valid data but got error {e}",
+                    self.formerly
+                )
+            }
+        };
+        Some(msg)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TestSuite {
+    // pub description: Option<String>,
+    pub schema: TestSuiteSchema,
+    pub tests: Vec<Test>,
+}
+
+impl TestSuite {
+    /// Iterate over error messages.
+    pub fn test_deser_all<'a, T: std::fmt::Debug + DeserializeOwned>(
+        &'a self,
+    ) -> impl Iterator<Item = String> + 'a {
+        self.tests.iter().filter_map(|t| {
+            let msg = t.test_deser::<T>()?;
+            Some(format!("schema {}: {msg}", self.schema.id))
+        })
+    }
+}
+
+static TEST_SUITES: LazyLock<BTreeMap<(u64, u64), BTreeMap<String, TestSuite>>> =
+    LazyLock::new(|| {
+        VERSION_DIRS
+            .iter()
+            .map(|(ver, ver_path)| {
+                let mut suites = BTreeMap::default();
+                if ver < &(0, 5) {
+                    return (*ver, suites);
+                }
+                let suites_iter =
+                    ver_path
+                        .join("tests")
+                        .read_dir()
+                        .unwrap()
+                        .filter_map(|r_entry| {
+                            let entry = r_entry.ok()?;
+                            let fname_os = entry.file_name();
+                            let fname = fname_os.to_string_lossy();
+                            let mut stem = fname.strip_suffix(".json")?;
+                            if let Some(s) = stem.strip_suffix("_suite") {
+                                stem = s;
+                            }
+                            let contents = std::fs::read(entry.path()).unwrap();
+                            let suite: TestSuite = serde_json::from_slice(&contents).unwrap();
+                            Some((stem.to_string(), suite))
+                        });
+                suites.extend(suites_iter);
+                (*ver, suites)
+            })
+            .collect()
+    });
+
+/// Get example JSON for a given version, in a map from directory name to file stem to JSON content (comments stripped).
+pub fn get_examples(version: (u64, u64)) -> &'static BTreeMap<String, BTreeMap<String, String>> {
+    EXAMPLE_JSON
+        .get(&version)
+        .unwrap_or_else(|| panic!("Expected examples of version {}.{}", version.0, version.1))
+}
+
+pub fn get_test_suites(version: (u64, u64)) -> &'static BTreeMap<String, TestSuite> {
+    TEST_SUITES.get(&version).unwrap_or_else(|| {
+        panic!(
+            "Expected test suite for version {}.{}",
+            version.0, version.1
+        )
+    })
+}

--- a/src/v0_4.rs
+++ b/src/v0_4.rs
@@ -41,3 +41,34 @@ pub struct OmeNgffGroupAttributes {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub well: Option<Well>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tests::*;
+    
+    const VERSION: (u64, u64) = (0, 4);
+
+    #[test]
+    fn parse_examples() {
+        let mut msg = String::default();
+        let mut failed = 0;
+        let mut total = 0;
+        for (dname, map) in get_examples(VERSION) {
+            for (fname, content) in map {
+                total += 1;
+
+                let Err(e) = serde_json::from_str::<OmeNgffGroupAttributes>(content) else {
+                    continue;
+                };
+                failed += 1;
+                msg.push_str(&format!(
+                    "dir {dname}, example {fname}: failed with error {e}\n"
+                ));
+            }
+        }
+        if failed > 0 {
+            panic!("Failed {failed} of {total}:\n{}", msg.trim_end());
+        }
+    }
+}

--- a/src/v0_4/axes.rs
+++ b/src/v0_4/axes.rs
@@ -46,6 +46,18 @@ pub enum AxisUnit {
     Custom(String),
 }
 
+impl From<AxisUnitSpace> for AxisUnit {
+    fn from(value: AxisUnitSpace) -> Self {
+        Self::Space(value)
+    }
+}
+
+impl From<AxisUnitTime> for AxisUnit {
+    fn from(value: AxisUnitTime) -> Self {
+        Self::Time(value)
+    }
+}
+
 /// [`AxisUnit`] physical `space` units valid according to UDUNITS-2.
 #[non_exhaustive]
 #[allow(missing_docs)]

--- a/src/v0_5.rs
+++ b/src/v0_5.rs
@@ -51,7 +51,7 @@ pub struct OmeFields {
 }
 
 /// OME-Zarr top-level group attributes.
-/// 
+///
 /// This can be deserialised from a representation of a group's user attributes.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct OmeZarrGroupAttributes {
@@ -64,18 +64,20 @@ impl From<v0_4::OmeNgffGroupAttributes> for OmeZarrGroupAttributes {
         let ome = OmeFields {
             version: monostate::MustBe!("0.5"),
             bioformats2raw_layout: value.bioformats2raw_layout,
-            multiscales: value.multiscales.map(|v| v.into_iter().map(Into::into).collect()),
+            multiscales: value
+                .multiscales
+                .map(|v| v.into_iter().map(Into::into).collect()),
             labels: value.labels,
             image_label: value.image_label.map(Into::into),
             plate: value.plate.map(Into::into),
-            well: value.well.map(Into::into),  
+            well: value.well.map(Into::into),
         };
-        Self {ome}
+        Self { ome }
     }
 }
 
 /// OME-Zarr top-level group metadata.
-/// 
+///
 /// This can be deserialised from a representation of the whole metadata document
 /// (i.e. the contents of `zarr.json` in zarr v3, which includes user attributes and core metadata).
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/src/v0_5.rs
+++ b/src/v0_5.rs
@@ -62,7 +62,7 @@ pub struct OmeZarrGroupAttributes {
 impl From<v0_4::OmeNgffGroupAttributes> for OmeZarrGroupAttributes {
     fn from(value: v0_4::OmeNgffGroupAttributes) -> Self {
         let ome = OmeFields {
-            version: monostate::MustBe!("0.5"),
+            version: Default::default(),
             bioformats2raw_layout: value.bioformats2raw_layout,
             multiscales: value
                 .multiscales

--- a/src/v0_5/labels.rs
+++ b/src/v0_5/labels.rs
@@ -21,6 +21,16 @@ pub struct ImageLabel {
     pub source: Option<ImageLabelSource>,
 }
 
+impl From<crate::v0_4::ImageLabel> for ImageLabel {
+    fn from(value: crate::v0_4::ImageLabel) -> Self {
+        Self {
+            colors: value.colors,
+            properties: value.properties,
+            source: value.source,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::v0_5::OmeZarrGroupMetadata;

--- a/src/v0_5/multiscales.rs
+++ b/src/v0_5/multiscales.rs
@@ -28,6 +28,12 @@ pub struct MultiscaleImage {
     pub metadata: Option<MultiscaleImageMetadata>,
 }
 
+impl From<crate::v0_4::MultiscaleImage> for MultiscaleImage {
+    fn from(value: crate::v0_4::MultiscaleImage) -> Self {
+        Self { name: value.name, axes: value.axes, datasets: value.datasets, coordinate_transformations: value.coordinate_transformations, r#type: value.r#type, metadata: value.metadata }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::v0_5::OmeZarrGroupMetadata;

--- a/src/v0_5/multiscales.rs
+++ b/src/v0_5/multiscales.rs
@@ -30,7 +30,14 @@ pub struct MultiscaleImage {
 
 impl From<crate::v0_4::MultiscaleImage> for MultiscaleImage {
     fn from(value: crate::v0_4::MultiscaleImage) -> Self {
-        Self { name: value.name, axes: value.axes, datasets: value.datasets, coordinate_transformations: value.coordinate_transformations, r#type: value.r#type, metadata: value.metadata }
+        Self {
+            name: value.name,
+            axes: value.axes,
+            datasets: value.datasets,
+            coordinate_transformations: value.coordinate_transformations,
+            r#type: value.r#type,
+            metadata: value.metadata,
+        }
     }
 }
 

--- a/src/v0_5/plate.rs
+++ b/src/v0_5/plate.rs
@@ -29,6 +29,19 @@ pub struct Plate {
     pub wells: Vec<PlateWell>,
 }
 
+impl From<crate::v0_4::Plate> for Plate {
+    fn from(value: crate::v0_4::Plate) -> Self {
+        Self {
+            acquisitions: value.acquisitions,
+            columns: value.columns,
+            field_count: value.field_count,
+            name: value.name,
+            rows: value.rows,
+            wells: value.wells,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::v0_5::OmeZarrGroupMetadata;

--- a/src/v0_5/well.rs
+++ b/src/v0_5/well.rs
@@ -14,11 +14,11 @@ pub struct Well {
     pub images: Vec<WellImage>,
 }
 
-
 impl From<crate::v0_4::Well> for Well {
-
     fn from(value: crate::v0_4::Well) -> Self {
-        Self { images: value.images }
+        Self {
+            images: value.images,
+        }
     }
 }
 

--- a/src/v0_5/well.rs
+++ b/src/v0_5/well.rs
@@ -14,6 +14,14 @@ pub struct Well {
     pub images: Vec<WellImage>,
 }
 
+
+impl From<crate::v0_4::Well> for Well {
+
+    fn from(value: crate::v0_4::Well) -> Self {
+        Self { images: value.images }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::v0_5::OmeZarrGroupMetadata;


### PR DESCRIPTION
Based on #8 .

Parses all valid JSON files (after stripping comments) from the spec examples and makes them available to unit tests.

Also parses the `tests` JSON from the v0.5 spec for valid and invalid metadata and makes them available for testing too.